### PR TITLE
Trial Spawner block should spawn entities with proper tags

### DIFF
--- a/src/main/java/net/salju/trialstowers/block/TrialSpawnerBlock.java
+++ b/src/main/java/net/salju/trialstowers/block/TrialSpawnerBlock.java
@@ -1,8 +1,11 @@
 package net.salju.trialstowers.block;
 
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.phys.HitResult;
 import net.salju.trialstowers.init.TrialsProperties;
 import net.salju.trialstowers.init.TrialsBlockEntities;
-import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.BlockState;
@@ -19,9 +22,9 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionHand;
-import net.minecraft.util.Mth;
 import net.minecraft.core.BlockPos;
-import javax.annotation.Nullable;
+
+import javax.annotation.Nullable;
 
 public class TrialSpawnerBlock extends BaseEntityBlock {
 	public static final BooleanProperty ACTIVE = TrialsProperties.ACTIVE;
@@ -86,4 +89,27 @@ public class TrialSpawnerBlock extends BaseEntityBlock {
 	public boolean isCursed(BlockState state) {
 		return state.getValue(CURSED);
 	}
-}
+
+	@Override
+	public ItemStack getCloneItemStack(BlockState state, HitResult hitResult, BlockGetter level, BlockPos pos, Player player) {
+		// include all the data from the block entity
+		BlockEntity entity = level.getBlockEntity(pos);
+		if (entity instanceof TrialSpawnerEntity target) {
+			ItemStack stack = super.getCloneItemStack(state, hitResult, level, pos, player);
+			stack.addTagElement("BlockEntityTag", target.getUpdateTag());
+			return stack;
+		}
+		return super.getCloneItemStack(state, hitResult, level, pos, player);
+	}
+
+	@Override
+	public void setPlacedBy(Level world, BlockPos pos, BlockState state, @Nullable LivingEntity livingEntity, ItemStack stack) {
+		super.setPlacedBy(world, pos, state, livingEntity, stack);
+		if (stack.hasTag() && stack.getTag().contains("BlockEntityTag")) {
+			BlockEntity entity = world.getBlockEntity(pos);
+			if (entity instanceof TrialSpawnerEntity spawnerEntity) {
+				spawnerEntity.load(stack.getTag().getCompound("BlockEntityTag"));
+			}
+		}
+	}
+}


### PR DESCRIPTION
Hello! 

## Context 
I was using your mod in the modpack I play with my friends, then I decided to create custom dungeons using the Trial Spawner. I noticed it already handles custom loot tables by changing the `LootTable` tag in the Trial Spawner block entity.

However, assigning a modified spawn egg with entity tags to it doesn't spawn the mobs correctly. The mob ID is preserved but no entity tag is passed to the spawned mobs.

I also missed a way to disable the equipped armor and effects the spawner gives to mobs, in case a custom Trial Spawner wants to set its own equipments and effects to the entities (which is my case!).

## What this PR is doing

To address the problems I'm trying to solve:
- "Spawned entities doesn't carry the custom entity tags defined by the spawn egg"
To solve this I changed the implementation of the `setUpMob` function to receive the spawn egg item and use its own `type.spawn` function to properly spawn the entity with all tags instead of using `level.addFreshEntity`. All the equipment and effects are applied after the entity is created.

- "Custom Trial Spawners could be able to not set the default equipments and effects"
I added a tag `DisableEffects` to the Trial Spawner block entity, it is default false (so your coded behavior can happen) and can be set to true via commands. This tag will avoid setting the default equipments and effects to spawned entities, allowing it to follow the entity tags defined in the spawn egg without interferences.

## Extra
If you look at the Trial Spawner block code, I added the implementation to `getCloneItemStack` and `setPlacedBy`. Basically it allow players in creative mode to middle click the Trial Spawner block and get an item version of it with all the tags, containing the entity it will spawn, the difficulty, etc. 

And when this Trial Spawner block item is placed it will clone all the tags to the spawned block entity. Making it a perfect copy of the original Trial Spawner you middle-clicked! The goal with it is to easily use the Trial Spawners to make custom dungeons!

## Using it
The following command will give you a Trial Spawner item that when placed, set up the spawner to create waves of baby zombies named Joe, with the default equipments and effects disabled!

`/give @p trials:trial_spawner{BlockEntityTag:{isActive:0b, DisableEffects:1b, SpawnEgg: {id: "minecraft:zombie_spawn_egg", tag:{EntityTag:{CustomNameVisible:1b,CustomName:'{"text":"Joe"}', IsBaby: 1}}, Count: 1b}, Difficulty:90}}`

This other command just gives a Trial Spawner with disabled effects:
`/give @p trials:trial_spawner{BlockEntityTag:{DisableEffects:1b}}`


And this one gives a Zombie spawn egg that will always spawn a baby zombie named Joe:
`/give @p minecraft:zombie_spawn_egg{EntityTag:{id:"minecraft:zombie",IsBaby:1b,CustomName:'{"text":"Joe"}'}}
`

Thanks for the mod! I hope you consider my implementations!

<img width="563" alt="java 2024-11-01 13 46 23" src="https://github.com/user-attachments/assets/dd6043c1-770e-420e-8851-4ed83de5073e">